### PR TITLE
Update to libc 0.2.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mmap"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Rick Branson <rick@diodeware.com>", "The Rust Project Developers"]
 license = "MIT"
 readme = "README.md"
@@ -11,5 +11,5 @@ A library for dealing with memory-mapped I/O
 """
 
 [dependencies]
-libc = "0.1.6"
+libc = "0.2"
 tempdir = "0.3"


### PR DESCRIPTION
As this crate doesn't expose any of the libc types externally, I believe a patch version bump should be sufficient.
