### PR TITLE
Fix cargo audit warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,6 @@ A library for dealing with memory-mapped I/O
 
 [dependencies]
 libc = "0.1.6"
-tempdir = "0.3"
+
+[dev-dependencies]
+tempfile = "3.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,7 +257,7 @@ impl MemoryMap {
         } else {
             Ok(MemoryMap {
                 data: r as *mut u8,
-                len: len,
+                len,
                 kind: if fd == -1 {
                     MapVirtual
                 } else {
@@ -354,7 +354,7 @@ impl MemoryMap {
                 0 => Err(ErrVirtualAlloc()),
                 _ => Ok(MemoryMap {
                     data: r as *mut u8,
-                    len: len,
+                    len,
                     kind: MapVirtual,
                 }),
             }
@@ -388,7 +388,7 @@ impl MemoryMap {
                     0 => Err(ErrMapViewOfFile(errno())),
                     _ => Ok(MemoryMap {
                         data: r as *mut u8,
-                        len: len,
+                        len,
                         kind: MapFile(mapping as *const u8),
                     }),
                 }
@@ -451,6 +451,11 @@ impl MemoryMap {
     #[inline(always)]
     pub fn len(&self) -> usize {
         self.len
+    }
+
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 
     /// Returns the type of mapping this represents.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -467,7 +467,7 @@ impl MemoryMap {
 #[cfg(test)]
 mod tests {
     extern crate libc;
-    extern crate tempdir;
+    extern crate tempfile;
 
     use super::{MapOption, MemoryMap};
 
@@ -503,7 +503,7 @@ mod tests {
             file.as_raw_handle()
         }
 
-        let tmpdir = tempdir::TempDir::new("").unwrap();
+        let tmpdir = tempfile::tempdir().unwrap();
         let mut path = tmpdir.path().to_path_buf();
         path.push("mmap_file.tmp");
         let size = MemoryMap::granularity() * 2;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -512,7 +512,7 @@ mod tests {
             .open(&path)
             .unwrap();
         file.seek(SeekFrom::Start(size as u64)).unwrap();
-        file.write(b"\0").unwrap();
+        file.write_all(b"\0").unwrap();
         let fd = get_fd(&file);
 
         let chunk = MemoryMap::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,6 @@ pub struct MemoryMap {
 }
 
 /// Type of memory map
-#[allow(raw_pointer_derive)]
 #[derive(Copy, Clone)]
 pub enum MemoryMapKind {
     /// Virtual memory map. Usually used to change the permissions of a given
@@ -66,7 +65,6 @@ pub enum MemoryMapKind {
 }
 
 /// Options the memory map is created with
-#[allow(raw_pointer_derive)]
 #[derive(Copy, Clone)]
 pub enum MapOption {
     /// The memory should be readable


### PR DESCRIPTION
I get a `cargo audit` warning as `perfcnt` depends on your crate and you use the `tempdir` crate: https://github.com/jbreitbart/criterion-perf-events/issues/2

I also fixed a few clippy/linter warnings.